### PR TITLE
Added fallback support for in-assembly logger factories if / when a failure to identify additional factories fails.

### DIFF
--- a/CqlSharp/Logging/LoggerManager.cs
+++ b/CqlSharp/Logging/LoggerManager.cs
@@ -106,8 +106,13 @@ namespace CqlSharp.Logging
             }
             catch
             {
-                //in case of any loading errors, assume no factories are loaded
-                LoggerFactories = new List<ILoggerFactory>();
+                //in case of any loading errors, load only the loggers that we implement
+                LoggerFactories = new List<ILoggerFactory>()
+                {
+                    new NullLoggerFactory(),
+                    new ConsoleLoggerFactory(),
+                    new DebugLoggerFactory()
+                };
             }
         }
     }


### PR DESCRIPTION
At times some assemblies cause SatisfyImportsOnce to fail, this change provides a fallback to the "known" LoggerFactories.
