### PR TITLE
Tweak TimeUuid generator to handle extremely fast generation cases

### DIFF
--- a/CqlSharpTest/IssueTest.cs
+++ b/CqlSharpTest/IssueTest.cs
@@ -16,7 +16,9 @@
 using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Fakes;
+using System.Numerics;
 using System.Threading.Tasks;
 
 namespace CqlSharp.Test
@@ -55,6 +57,23 @@ namespace CqlSharp.Test
                 {
                     await connection.OpenAsync();
                 }
+            }
+        }
+
+        [TestMethod]
+        public void TimeUuidIssue()
+        {
+            // this test uses BigInteger to check, otherwise the Dictionary
+            // will complain because Guid's GetHashCode will collide
+            var timestamps = new Dictionary<BigInteger, Guid>();
+
+            // run a full clock sequence cycle (or so)
+            for (var n = 0; n < 65536; n++)
+            {   
+                var guid = DateTime.Now.GenerateTimeBasedGuid();
+                var bigint = new BigInteger(guid.ToByteArray());
+
+               timestamps.Add(bigint, guid);
             }
         }
     }


### PR DESCRIPTION
There were two issues with the timeuuid generator: the sequence number
was essentially a random, but should really be a monotonically
increasing value in case we run into sub 100ns requests, and the
sequence number is actually reversed in the resulting guid on little
endian machines. Added a unit test that runs through at least one full
sequence number cycle to verify that we're generating unique guids.
Fixed the generated node is to mark is as locally administered /
multicast per rfc4122.
