### PR TITLE
changed MEF search folder resolving

### DIFF
--- a/CqlSharp/Extensions/Loader.cs
+++ b/CqlSharp/Extensions/Loader.cs
@@ -13,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 using System.IO;
-using System.Reflection;
 using CqlSharp.Authentication;
 using CqlSharp.Logging;
 
@@ -87,12 +87,14 @@ namespace CqlSharp.Extensions
             var catalog = new AggregateCatalog();
 
             //go and search for ILoggerFactories in executing directory
-            string path = Directory.GetParent(Assembly.GetExecutingAssembly().Location).ToString();
+            string path = AppDomain.CurrentDomain.BaseDirectory;
             catalog.Catalogs.Add(new DirectoryCatalog(path, conventions));
 
+            string subPath = AppDomain.CurrentDomain.RelativeSearchPath;
+
             //or in bin directory (asp.net)
-            if (Directory.Exists(path + "\\bin"))
-                catalog.Catalogs.Add(new DirectoryCatalog(path + "\\bin", conventions));
+            if (!string.IsNullOrEmpty(subPath) && Directory.Exists(subPath))
+                catalog.Catalogs.Add(new DirectoryCatalog(subPath, conventions));
 
             //create container
             var container = new CompositionContainer(catalog, CompositionOptions.Default);


### PR DESCRIPTION
I were trying to figure out why my logger wasn't attached to CqlSharp. This is what I've got when attached VS debugger to my IIS web site, that uses CqlSharp. 

![cqlsharp-loader](https://cloud.githubusercontent.com/assets/4157587/3625759/ffb51bba-0e71-11e4-8324-e9acea6825ad.png)

As you can see `Assembly.GetExecutingAssembly().Location` points to temporary ASP.NET folder that contains only CqlSharp.dll, nothing more. MEF cannot load any imports in this case ;)
AppDomain.CurrentDomain contains right paths in `BaseDirectory` and `RelativeSearchPath` properties. In case of .exe app the `RelativeSearchPath` property is null.
