### PR TITLE
Update CqlConsistency.cs

### DIFF
--- a/CqlSharp/CqlConsistency.cs
+++ b/CqlSharp/CqlConsistency.cs
@@ -34,6 +34,8 @@ namespace CqlSharp
 
         LocalQuorum = 0x0006,
 
-        EachQuorum = 0x0007
+        EachQuorum = 0x0007,
+        
+        LocalOne = 0x000A
     }
 }


### PR DESCRIPTION
Extending CqlConsistency enum with the LocalOne (0x000A) consistency level based on https://git-wip-us.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=doc/native_protocol.spec;hb=refs/heads/cassandra-1.2
