### PR TITLE
Time uuid clock sequence entropy

### DIFF
--- a/CqlSharp/TimeGuid.cs
+++ b/CqlSharp/TimeGuid.cs
@@ -143,21 +143,21 @@ namespace CqlSharp
             //capture values
             var sequence = ClockSequenceNumber;
 
-            var assumedLastTime = _lastTime;
             if (node == null)
             {
-                if (time < assumedLastTime)
+                if (time < _lastTime)
                 {
                     _nodeId = CreateNodeId();
                 }
 
                 node = _nodeId;
+
+                // we are less interested in locking this now
+                // since it's only used to give us additional entropy
+                // when we aren't given a MAC address
+                _lastTime = time;
             }
 
-            // we are less interested in locking this now
-            // since it's only used to give us additional entropy
-            // when we aren't given a MAC address
-            _lastTime = time;
             return GenerateTimeBasedGuid(time, (int)sequence, node);
         }
 

--- a/CqlSharpTest/TimeUuidTest.cs
+++ b/CqlSharpTest/TimeUuidTest.cs
@@ -30,17 +30,33 @@ namespace CqlSharp.Test
         public void TimeUuidIssue()
         {
             var baseDate = DateTime.UtcNow;
-            var generatedGuids = new Guid[10000];
+            var generatedGuids = new Guid[50000];
 
-            byte[] mac = new byte[] { 0x33, 0x30, 0xa0, 0x80, 0x10, 0x88 };
-            
             Parallel.For(0, generatedGuids.Length, i =>
             {
-                generatedGuids[i] = baseDate.AddTicks(i % 100).GenerateTimeBasedGuid(mac);
+                generatedGuids[i] = baseDate.AddTicks(i % 3).GenerateTimeBasedGuid();
             });
 
             var hashOfGuids = new HashSet<Guid>(generatedGuids);
-            Assert.AreEqual(generatedGuids.Length, hashOfGuids.Count); 
+            Assert.AreEqual(generatedGuids.Length, hashOfGuids.Count);
+        }
+
+        [TestMethod]
+        public void MultiThreadedTimeUuidIssue()
+        {
+            var baseDate = DateTime.UtcNow;
+            var generatedGuids = new Guid[10000];
+
+            byte[] mac = { 0x33, 0x30, 0xa0, 0x80, 0x10, 0x88 };
+
+            Parallel.For(0, generatedGuids.Length, i =>
+            {
+                generatedGuids[i] = baseDate.AddTicks(i % 10).GenerateTimeBasedGuid(mac);
+            });
+
+            var hashOfGuids = new HashSet<Guid>(generatedGuids);
+            Assert.AreEqual(generatedGuids.Length, hashOfGuids.Count);
+            Assert.IsTrue(generatedGuids.All(g => g.ToString().EndsWith("3330a0801088")));
         }
 
         [TestMethod]


### PR DESCRIPTION
Previously, the fix only worked when the user didn't provide a node id / MAC address. The lack of variability in the sequence number was made up for by regenerating a node id. However, on a fleet of many machines on a network needing to each generate unique uuids, we actually need to use time uuid per the RFC 4122. As such, only having the variability when node id is not used wasn't workable. 

Instead of relying on entropy in the node id itself, when the node is provided, this uses a static, always incrementing integer to ensure unique clock sequence numbers throughout a cycle of the entire 14 bit space rather than just a 1 bit space. It's still not perfect but it ensures that as long as multiple datetimes with the same tick value are inserted in the same 16,384 request cycle, they will get unique identifiers, even if the mac address is supplied.

As a bonus, this allowed us to get less lock heavy. It maintains the node variability when mac address isn't used but relies on it less and thus can operate without locking.

There are 2 tests. The one that @michaeljon put in, but was updated. And the other one that actually uses a mac address.
